### PR TITLE
Add lock for simultaneous requests, clarify documentation, and fix TCP CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build
 dist
 *.egg-info
+venv

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Example Connections
    * Good for newer computers and maker boards such as Raspberry Pis.
  * Cables routed through a [TCP device server](https://www.amazon.com/gp/product/B00I5EYB2Q) (`tcp://192.168.1.100:4000`, requires python >3.4).
     * Good in conjunction with PLCs for professional-looking control boxes.
- * Multiple cables connected to one port via a [splitter](https://www.amazon.com/gp/product/B007F2E188) and Alicat's addressing (`A`-`D`).
+ * Multiple cables connected to one port via a [splitter](https://www.amazon.com/gp/product/B007F2E188) and Alicat's addressing (`A`-`Z`).
     * Good when number of ports is limited.
 
 Installation

--- a/alicat/tcp.py
+++ b/alicat/tcp.py
@@ -83,6 +83,9 @@ class FlowMeter(object):
 
             if address != self.address:
                 raise ValueError("Flow controller address mismatch.")
+            if '=' in values:
+                raise ValueError(f'Received reply {values} intended for another request. '
+                                 f'Are there simultaneous connections?')
             if len(values) == 5 and len(self.keys) == 6:
                 del self.keys[-2]
             elif len(values) == 7 and len(self.keys) == 6:

--- a/alicat/tcp.py
+++ b/alicat/tcp.py
@@ -165,8 +165,9 @@ class FlowController(FlowMeter):
     [Reference](http://www.alicat.com/products/mass-flow-meters-and-
     controllers/mass-flow-controllers/).
 
-    This communicates with the flow controller over a USB or RS-232/RS-485
-    connection using pyserial.
+    This communicates with the flow controller over a TCP bridge such as the
+    [StarTech Device Server](https://www.startech.com/Networking-IO/
+    Serial-over-IP/4-Port-Serial-Ethernet-Device-Server-with-PoE~NETRS42348PD).
 
     To set up your Alicat flow controller, power on the device and make sure
     that the "Setpoint Source" option is set to "Serial".
@@ -174,14 +175,15 @@ class FlowController(FlowMeter):
 
     registers = {'flow': 0b00100101, 'pressure': 0b00100010}
 
-    def __init__(self, port='/dev/ttyUSB0', address='A'):
-        """Connect this driver with the appropriate USB / serial port.
+    def __init__(self, ip, port, address='A'):
+        """Initialize the device client.
 
         Args:
-            port: The serial port. Default '/dev/ttyUSB0'.
+            ip: IP address of the device server
+            port: Port of the device server
             address: The Alicat-specified address, A-Z. Default 'A'.
         """
-        FlowMeter.__init__(self, port, address)
+        FlowMeter.__init__(self, ip, port, address)
 
         async def f():
             try:
@@ -292,7 +294,7 @@ def command_line(args):
     import json
     from time import time
 
-    ip, port = args.port[6:].split(':')
+    ip, port = args.port[6:].split(':')  # strip 'tcp://'
     port = int(port)
     flow_controller = FlowController(ip, port, args.address)
 

--- a/alicat/tcp.py
+++ b/alicat/tcp.py
@@ -1,4 +1,4 @@
-"""Python driver for Alicat mass flow controllers, using asynchronous TCP.
+"""Python driver for Alicat mass flow meters and controllers, using asynchronous TCP.
 
 Distributed under the GNU General Public License v2
 Copyright (C) 2019 NuMat Technologies
@@ -20,6 +20,9 @@ class FlowMeter(object):
     This communicates with the flow meter over a TCP bridge such as the
     [StarTech Device Server](https://www.startech.com/Networking-IO/
     Serial-over-IP/4-Port-Serial-Ethernet-Device-Server-with-PoE~NETRS42348PD).
+
+    To set up your Alicat flow meter, power on the device and make sure
+    that the "Setpoint Source" option is set to "Serial".
     """
 
     def __init__(self, ip, port, address='A'):
@@ -53,9 +56,9 @@ class FlowMeter(object):
         self.open = True
 
     async def get(self):
-        """Get the current state of the flow controller.
+        """Get the current state of the flow meter.
 
-        From the Alicat mass flow controller documentation, this data is:
+        From the Alicat mass flow meter documentation, this data is:
          * Pressure (normally in psia)
          * Temperature (normally in C)
          * Volumetric flow (in units specified at time of order)
@@ -166,7 +169,7 @@ class FlowController(FlowMeter):
     connection using pyserial.
 
     To set up your Alicat flow controller, power on the device and make sure
-    that the "Input" option is set to "Serial".
+    that the "Setpoint Source" option is set to "Serial".
     """
 
     registers = {'flow': 0b00100101, 'pressure': 0b00100010}

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ universal = 1
 
 [flake8]
 max-complexity = 15
-max-line-length = 89
+max-line-length = 99

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as in_file:
 
 setup(
     name="alicat",
-    version="0.2.10",
+    version="0.3.0",
     description="Python driver for Alicat mass flow controllers.",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Use `asyncio.Lock` to handle simultaneous requests from the same source.
Add a bit more help error messages for simultaneous requests from different sources.
Clarify documentation, including distinguishing MFC/MFM.
Fix the CLI for TCP connections.