### PR TITLE
Improve command line by awaiting coroutines, and waiting for init

### DIFF
--- a/alicat/tcp.py
+++ b/alicat/tcp.py
@@ -189,8 +189,8 @@ class FlowController(FlowMeter):
         FlowMeter.__init__(self, ip, port, address)
 
         self.control_point = 'unknown'
-        asyncio.ensure_future(self._get_control_point())
         self.init_lock = asyncio.Lock()
+        asyncio.ensure_future(self._get_control_point())
 
     async def get(self):
         """Get the current state of the flow controller.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as in_file:
 
 setup(
     name="alicat",
-    version="0.3.0",
+    version="0.3.1",
     description="Python driver for Alicat mass flow controllers.",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Closes #25 
- Use `await` properly for the command line interface
- Add warning if `_get_control_point()` gets an unexpected reply due to crosstalk
- Change `_get_control_point() to update `FlowController.control_point`.  (Use a side effect to keep the return value the same).
- Remove unneeded `async def(f)` in constructor, and add an `asyncio.Lock()` to make sure initialization finishes before any other command line functions execute.