### PR TITLE
Close communications port upon context manager exit

### DIFF
--- a/alicat/driver.py
+++ b/alicat/driver.py
@@ -52,6 +52,7 @@ class FlowMeter:
 
     async def __aexit__(self, *args: Any) -> None:
         """Provide async exit to context manager."""
+        await self.close()
         return
 
     @classmethod


### PR DESCRIPTION
Close the FlowMeter comport when the context manager exits