### PR TITLE
modified close method according to recommendation in asyncio docs

### DIFF
--- a/alicat/util.py
+++ b/alicat/util.py
@@ -181,7 +181,8 @@ class TcpClient(Client):
     async def close(self) -> None:
         """Close the TCP connection."""
         if self.open:
-            await self.connection['writer'].close()
+            self.connection['writer'].close()
+            await self.connection['writer'].wait_closed()
         self.open = False
 
 


### PR DESCRIPTION
I was getting a TypeError (NoneType) when closing a TCP connection.

By modifying the close method according to the [asyncio StreamWriter close method](https://docs.python.org/3/library/asyncio-stream.html#asyncio.StreamWriter.close) docs, the issue was resolved.