### PR TITLE
Fixed an f-string in FlowMeter._test_controller_open

### DIFF
--- a/alicat/driver.py
+++ b/alicat/driver.py
@@ -96,7 +96,7 @@ class FlowMeter:
         """
         if not self.open:
             raise OSError(f"The FlowMeter with unit ID {self.unit} and "
-                           "port {self.hw.address} is not open")
+                          f"port {self.hw.address} is not open")
 
     async def _write_and_read(self, command: str) -> str | None:
         """Wrap the communicator request, to call _test_controller_open() before any request."""


### PR DESCRIPTION
The _test_controller_open function raised an improperly formatted f-string in its OSError. 

Notably, before this fix, I was receiving the `OSError "Could not read control point"` on line 520 during the initialization of the device. However, after this fix, the call to `_test_controller_open()` in `_write_and_read()` now correctly raises the associated error instead of the "Could not read control point" error. This is the expected behaviour, as I had not connected a device to the COM port. I cannot explain why this behaviour occurred. 